### PR TITLE
Improve spacing and layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -27,10 +27,18 @@ body {
   min-height: 100vh;
 }
 
+header {
+  margin-bottom: 2rem;
+}
+
+.container {
+  padding: 4rem 1rem;
+}
+
 .row {
   background-color: var(--overlay-color);
-  padding: 1rem;
-  margin: 1rem;
+  padding: 2rem;
+  margin: 2rem 0;
   border-radius: 0.5em;
   text-align: center;
   backdrop-filter: blur(4px);
@@ -42,6 +50,8 @@ body {
   border-radius: 0.5em;
   box-shadow: 0 4px 8px rgb(0 0 0 / 40%);
   backdrop-filter: blur(4px);
+  padding: 2rem;
+  margin-bottom: 2rem;
 }
 
 .cta-card {
@@ -50,13 +60,15 @@ body {
   border-radius: 0.5em;
   box-shadow: 0 4px 8px rgb(0 0 0 / 40%);
   backdrop-filter: blur(4px);
+  padding: 3rem 2rem;
+  margin: 2rem 0;
 }
 
 hr {
   background-color: var(--text-color, white);
-  width: 15rem;
+  width: 25rem;
   height: 0.1rem;
-  margin: 2em auto;
+  margin: 3em auto;
   border-radius: 1em;
 }
 
@@ -128,7 +140,7 @@ p {
   font-size: 1rem;
   font-weight: 300;
   text-shadow: 0 1px 2px rgb(0 0 0 / 60%);
-  margin: 1em 0 0;
+  margin: 1.5em 0;
 }
 
 footer {
@@ -140,7 +152,7 @@ footer {
   font-size: 0.875rem;
   background-color: rgb(0 0 0 / 80%);
   text-align: center;
-  padding: 5px;
+  padding: 1rem;
 }
 
 .btn {
@@ -166,7 +178,7 @@ footer {
 }
 
 img {
-  margin: 0 1em 1em 0;
+  margin: 0 1.5em 1.5em 0;
   padding: 0;
   transition: all 0.5s;
   transition-delay: 0.08s;


### PR DESCRIPTION
## Summary
- apply generous padding for container rows
- add more space in info/cta cards and footer
- widen the page divider
- tweak margins for text and icons for a cleaner layout

## Testing
- `npx stylelint style.css`
- `npx htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_685e0310c850832fa46ab9fc06238b35