### PR TITLE
Improve responsive text scaling

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,6 +9,16 @@
   --font-main: 'Inter', Arial, sans-serif;
 }
 
+/*
+ * Scale the base font size with the viewport so that text adjusts
+ * smoothly across different device sizes. This helps ensure the
+ * entire page fits vertically on small screens without manual
+ * zooming.
+ */
+html {
+  font-size: clamp(14px, 1.2vw + 1.2vh, 20px);
+}
+
 html, body {
   height: 100%;
   margin: 0;
@@ -37,6 +47,8 @@ body::before { content:""; position: fixed; inset:0; background: var(--overlay-c
   padding: 2rem;
   max-width: 600px;
   width: 100%;
+  max-height: 100vh;
+  overflow-y: auto;
 }
 
 h1 {
@@ -131,5 +143,13 @@ footer {
   }
   footer {
     margin-top: 1.5rem;
+  }
+}
+
+/* Further reduce font sizes on very short screens so all content
+   stays within the viewport without scrolling. */
+@media (max-height: 700px) {
+  html {
+    font-size: clamp(12px, 1vw + 1vh, 18px);
   }
 }


### PR DESCRIPTION
## Summary
- adapt base font size with a clamp based on viewport units
- cap `.glass-card` height and enable scrolling if needed
- shrink font sizes on short screens

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d8e96c7cc832f995de7f91ad542d1