### PR TITLE
Responsive design rewrite: fluid cascade, no breakpoint cliffs

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "site",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["--yes", "serve", "-l", "4173", "."],
+      "port": 4173
+    }
+  ]
+}

--- a/style.css
+++ b/style.css
@@ -9,13 +9,18 @@
   --font-main: 'Inter', arial, sans-serif;
 }
 
-/* Base type scales smoothly but doesn't drop to unreadable sizes */
+/*
+ * Fluid base type. Linear from 15px → 18px across viewports.
+ * Reaches max around ~1170px viewport, stays at 18px above that.
+ *
+ * `overflow-x: clip` prevents any rogue horizontal scrollbar (e.g. from
+ * the entrance animation's translateY) without creating a stacking context.
+ */
 html {
-  /* FIX: raise minimum size; keep smooth scaling */
-  font-size: clamp(12px, 1.1vw + 0.6vh, 20px);
+  font-size: clamp(15px, 0.6vw + 11px, 18px);
+  overflow-x: clip;
 }
 
-/* Ensure padding and borders don't increase element width */
 *, *::before, *::after {
   box-sizing: border-box;
 }
@@ -37,22 +42,29 @@ html, body {
 }
 
 body {
-  /* keep your background; fixed can be heavy on mobile but we preserve intent */
-  background: var(--bg-image) no-repeat center center fixed;
+  /*
+   * Background-attachment: scroll across the board.
+   * `fixed` is broken on iOS Safari and a perf hit on mobile.
+   */
+  background: var(--bg-color) var(--bg-image) no-repeat center center;
   background-size: cover;
   color: var(--text-color);
   font-family: var(--font-main), sans-serif;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
 
-  /* `safe center` falls back to top-align when content overflows, preventing clipping */
+  /*
+   * `safe center` falls back to start-alignment when content overflows the
+   * viewport, preventing the top of the card from being clipped offscreen.
+   */
+  justify-content: safe center;
   align-items: safe center;
-
-  /* FIX: allow pages taller than 1 viewport to scroll naturally */
   min-height: 100dvh;
-  padding: 2.5vh 2.5vw;
 
-  /* FIX: establish a stacking context so overlay can sit above bg but below content */
+  /* Fluid page padding scales smoothly from mobile to desktop */
+  padding: clamp(1rem, 3vw + 0.25rem, 3rem);
+
+  /* Stacking context so overlay sits above bg but below content */
   position: relative;
   z-index: 0;
 }
@@ -62,13 +74,10 @@ body::before {
   position: fixed;
   inset: 0;
   background: var(--overlay-color);
-
-  /* FIX: overlay above the background image but below content */
   z-index: 0;
-  pointer-events: none; /* don't block clicks */
+  pointer-events: none;
 }
 
-/* General responsive images (safety) */
 img {
   max-width: 100%;
   height: auto;
@@ -80,14 +89,21 @@ img {
   /* stylelint-disable-next-line property-no-vendor-prefix -- Safari <18 still needs the prefix */
   -webkit-backdrop-filter: blur(20px);
   backdrop-filter: blur(20px);
-  border-radius: 1rem;
+  border-radius: clamp(0.75rem, 1vw, 1.25rem);
   box-shadow: 0 4px 20px rgb(0 0 0 / 60%), inset 0 1px 0 rgb(255 255 255 / 8%);
   color: var(--text-color);
-  padding: 2rem;
-  width: 100%;
-  max-width: min(92vw, 64rem);
 
-  /* Ensure it renders above the overlay */
+  /* Fluid card padding — 1.25rem on small mobile up to 3rem on desktop */
+  padding: clamp(1.25rem, 4vw, 3rem);
+  width: 100%;
+
+  /*
+   * Single fluid max-width — no breakpoint jumps.
+   * Caps at 42rem (~672–756px depending on root font-size).
+   */
+  max-width: 42rem;
+
+  /* Render above the overlay */
   position: relative;
   z-index: 1;
   animation: glass-card-in 0.7s cubic-bezier(0.2, 0.8, 0.2, 1) both;
@@ -106,53 +122,50 @@ img {
 }
 
 h1 {
-  font-size: clamp(2rem, 5vw + 1vh, 3rem);
+  font-size: clamp(1.75rem, 4vw + 0.5rem, 2.75rem);
   font-weight: 700;
   letter-spacing: 0.05em;
-  margin-bottom: 0.5rem;
+  margin: 0 0 0.5rem;
+  line-height: 1.1;
 }
 
 .subtitle {
-  font-size: clamp(0.7rem, 2vw + 0.4vh, 0.9rem);
+  font-size: clamp(0.7rem, 0.6vw + 0.55rem, 0.875rem);
   font-weight: 400;
   text-transform: uppercase;
   letter-spacing: 0.18em;
   opacity: 0.85;
-
-  /* FIX: allow wrapping on narrow devices */
+  margin: 0 0 0.5rem;
   white-space: normal;
 }
 
 .cta-prompt {
-  font-size: clamp(0.85rem, 1.2vw + 0.4vh, 1rem);
+  font-size: clamp(0.85rem, 0.4vw + 0.75rem, 1rem);
   font-weight: 400;
   font-style: italic;
   opacity: 0.8;
-  margin-top: 0.5rem;
-  margin-bottom: 1rem;
+  margin: 0.5rem 0 1rem;
 }
 
 .location {
-  font-size: clamp(0.9rem, 2vw + 0.5vh, 1rem);
+  font-size: clamp(0.85rem, 0.4vw + 0.75rem, 1rem);
   opacity: 0.75;
-  margin-bottom: 1.5rem;
+  margin: 0 0 1.25rem;
 }
 
 hr {
   border: 0;
   height: 1px;
   background: linear-gradient(90deg, transparent, rgb(255 255 255 / 35%), transparent);
-  margin: 1.5rem auto;
+  margin: clamp(1rem, 2vw, 1.5rem) auto;
   width: min(60%, 30rem);
 }
 
 .description {
-  margin: 0 auto 2rem;
-
-  /* FIX: let text flow naturally in a readable measure */
+  margin: 0 auto clamp(1.25rem, 2vw, 2rem);
   width: 100%;
-  max-width: 60ch;
-  font-size: clamp(0.85rem, 1vw + 0.6vh, 1rem);
+  max-width: 52ch;
+  font-size: clamp(0.9rem, 0.4vw + 0.8rem, 1rem);
   line-height: 1.65;
   opacity: 0.92;
 }
@@ -183,10 +196,11 @@ hr {
 }
 
 footer {
-  font-size: 0.875rem;
+  font-size: clamp(0.75rem, 0.3vw + 0.7rem, 0.875rem);
   text-align: center;
-  margin-top: 2rem;
+  margin-top: clamp(1.25rem, 2vw, 2rem);
   color: rgb(255 255 255 / 75%);
+  line-height: 1.6;
 }
 
 footer a {
@@ -206,9 +220,9 @@ footer a:focus-visible {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 44px;
-  height: 44px;
-  margin: 0 0.5rem;
+  width: clamp(38px, 3vw + 28px, 44px);
+  height: clamp(38px, 3vw + 28px, 44px);
+  margin: 0 0.4rem;
   border-radius: 50%;
   color: rgb(255 255 255 / 85%);
   transition: transform 0.3s ease, color 0.3s ease, background-color 0.3s ease;
@@ -222,65 +236,62 @@ footer a:focus-visible {
 }
 
 .social-icons svg {
-  width: 24px;
-  height: 24px;
+  width: clamp(20px, 1.5vw + 14px, 24px);
+  height: clamp(20px, 1.5vw + 14px, 24px);
   display: block;
 }
 
-/* ===== Responsive tweaks ===== */
-@media (max-width: 768px) {
+/*
+ * Moderate short-viewport rule — covers common laptop heights
+ * (1366×768, 1280×800, iPad landscape 1024×768). Tightens vertical
+ * rhythm just enough to fit content without scroll on these displays.
+ */
+@media (max-height: 820px) {
   body {
-    /* On small screens, allow natural flow instead of centering everything via flex */
-    display: block;
-    padding: 1rem 0.5rem;
-
-    /* fixed-attachment background can jank on mobile */
-    background-attachment: scroll;
+    padding-top: clamp(0.5rem, 1.5vh, 1.5rem);
+    padding-bottom: clamp(0.5rem, 1.5vh, 1.5rem);
   }
 
   .glass-card {
-    margin: 1rem auto;
-    padding: 1.5rem;
-    max-width: 100%;
+    padding-top: clamp(1rem, 3vh, 2rem);
+    padding-bottom: clamp(1rem, 3vh, 2rem);
   }
 
-  .subtitle {
-    font-size: 0.75rem;
-  }
-}
-
-@media (max-width: 576px) {
-  h1 { font-size: 1.9rem; }
-
-  .subtitle { font-size: 0.7rem; }
-
-  .glass-card { padding: 1rem; }
-
-  .social-icons a {
-    width: 38px;
-    height: 38px;
-    margin: 0 0.25rem;
+  hr {
+    margin: 0.875rem auto;
   }
 
-  .social-icons svg {
-    width: 20px;
-    height: 20px;
+  .location {
+    margin-bottom: 0.75rem;
   }
 
-  footer { margin-top: 1.5rem; }
-}
+  .description {
+    margin-bottom: 1.25rem;
+    line-height: 1.55;
+  }
 
-/* If the viewport is short, keep type readable but compact */
-@media (max-height: 700px) {
-  html {
-    font-size: clamp(12px, 1vw + 1vh, 18px);
+  footer {
+    margin-top: 1rem;
   }
 }
 
-@media (min-width: 1024px) {
+/* Very short viewports — landscape phones, tiny chromebooks. */
+@media (max-height: 640px) {
   .glass-card {
-    max-width: min(80vw, 72ch);
-    padding: 3rem;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  hr {
+    margin: 0.5rem auto;
+  }
+
+  .location {
+    margin-bottom: 0.5rem;
+  }
+
+  .description {
+    margin-bottom: 0.875rem;
   }
 }
 


### PR DESCRIPTION
## Problem

- Centering broke at viewports < 768px — `display: block` kicked in there, dropping flex centering. Card stuck to top of viewport with empty space below on iPad portrait, small laptops, etc.
- Card sizing jumped abruptly at 576/768/1024 breakpoints
- Some sizes had unnecessary scrollbars

## Approach

Replace breakpoint-driven sizing with fluid `clamp()` formulas. Single centering pattern (flex column with `safe center`) at every viewport size — no more flex→block switch.

## What changed in `style.css`

**Centering**
- Body: `flex` column with `justify-content: safe center` + `align-items: safe center`. The `safe` keyword falls back to start-alignment when content overflows the viewport rather than clipping the top of the card offscreen.

**Fluid sizing — no breakpoint jumps**
- Page padding: `clamp(1rem, 3vw + 0.25rem, 3rem)`
- Card padding: `clamp(1.25rem, 4vw, 3rem)`
- Card max-width: single `42rem` cap
- Card border-radius: `clamp(0.75rem, 1vw, 1.25rem)` — slightly more rounded on big screens
- Base type: `clamp(15px, 0.6vw + 11px, 18px)` — linear 15→18 across viewports (was mixed `vw + vh` which jittered on extreme aspect ratios)
- All component fonts (`h1`, `.subtitle`, `.location`, `.description`, `.cta-prompt`, `.btn-primary`, footer, social-icons) now scale fluidly

**Background**
- Dropped `background-attachment: fixed` everywhere (broken on iOS Safari, perf hit on mobile). Was previously only swapped at 768px.

**Overflow safety**
- `html { overflow-x: clip }` — prevents rogue horizontal scrollbar from the entrance animation's `translateY`

**Short-viewport handling**
- `@media (max-height: 820px)` — moderate vertical tightening so common laptop displays (1366×768, 1280×800, iPad landscape 1024×768) fit without scroll
- `@media (max-height: 640px)` — aggressive tightening for landscape phones

## Verified

Tested centering, scroll behavior, and visual quality at:

| Viewport | Result |
|---|---|
| 280×653 (Galaxy Z Fold) | ✓ centered, scrolls naturally |
| 320×568 (iPhone SE) | ✓ minimal scroll, content fits well |
| 375×667 (iPhone 8) | ✓ centered, fits |
| 375×812 (iPhone X/14) | ✓ centered, fits |
| 414×896 (iPhone Pro Max) | ✓ centered, fits |
| 600×900 (small tablet) | ✓ centered both axes |
| 767×900 (just-below break) | ✓ centered (was broken) |
| 768×1024 (iPad portrait) | ✓ centered, generous spacing |
| 820×1180 (iPad Air portrait) | ✓ centered, fits |
| 1024×600 (short laptop) | ✓ overflow handled gracefully |
| 1024×768 (iPad landscape) | ✓ centered, fits cleanly |
| 1280×800 (small laptop) | ✓ fits without scroll |
| 1366×768 (common laptop) | ✓ fits without scroll |
| 1440×900 (laptop) | ✓ centered, fits |
| 1920×1080 (full HD) | ✓ centered, fits |
| 3440×1440 (ultrawide) | ✓ centered (max-width caps cleanly) |

## Lint

- HTMLHint: clean
- stylelint: clean

## Also includes

- `.claude/launch.json` — config for the local preview server I used to iterate visually (uses `npx serve` since python http.server is sandboxed on this machine)

## Test plan
- [ ] Resize browser slowly from 320px to 1920px — no abrupt layout jumps
- [ ] Visit at exactly 768px and 1024px — card stays centered through the transition
- [ ] iOS Safari — confirm background renders (no `fixed` attachment bug)
- [ ] Reduce-motion enabled → no entrance animation
- [ ] Tab through page — focus rings still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)